### PR TITLE
allow stylelint 15 peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tap-spec": "^5.0.0"
   },
   "peerDependencies": {
-    "stylelint": "10 - 14"
+    "stylelint": "10 - 15"
   },
   "eslintConfig": {
     "extends": "dev",


### PR DESCRIPTION
[Stlyelint 15 was released](https://github.com/stylelint/stylelint/releases/tag/15.0.0). As far as I can tell it doesn't have breaking changes that would effect this library, but npm will fail due to peer dependencies if this package is used with Stylelint 15.

I couldnt get tests to pass locally with or without this change. If I could get some guidance on how to proceed - if other dependencies need updating or something?