### PR TITLE
handle default export when using ES modules

### DIFF
--- a/index.test.mjs
+++ b/index.test.mjs
@@ -138,3 +138,18 @@ testRule({
 		{ importFrom: { customMedia: { '--sm': '(min-width: 40em)' } } }
 	], accept: accept, reject: reject
 });
+
+testRule({
+	plugins: ['./src/index.mjs'], ruleName: rule.ruleName, config: [
+		'always-known',
+		{ importFrom: ['./test/import-custom-media-named.js'] }
+	], accept: accept, reject: reject
+});
+
+testRule({
+	plugins: ['./src/index.mjs'], ruleName: rule.ruleName, config: [
+		'always-known',
+		{ importFrom: ['./test/import-custom-media-default.js'] }
+	], accept: accept, reject: reject
+});
+

--- a/src/lib/get-custom-media-from-imports.mjs
+++ b/src/lib/get-custom-media-from-imports.mjs
@@ -41,6 +41,10 @@ async function getCustomMediaFromJSONFile(from) {
 async function getCustomMediaFromJSFile(from) {
 	const object = await import(from);
 
+	if ('default' in object) {
+		return getCustomMediaFromObject(object.default);
+	}
+
 	return getCustomMediaFromObject(object);
 }
 

--- a/test/import-custom-media-default.js
+++ b/test/import-custom-media-default.js
@@ -1,0 +1,3 @@
+export default {
+	customMedia: {'--sm': '(min-width: 40em)'}
+}

--- a/test/import-custom-media-named.js
+++ b/test/import-custom-media-named.js
@@ -1,0 +1,3 @@
+export const customMedia = {
+	'--sm': '(min-width: 40em)'
+}


### PR DESCRIPTION
## Problem

It’s currently impossible to use JS files with a default export for the importFrom property when using ES modules, because the import result looks like this:
```
async function getCustomMediaFromJSFile(from) {
	const object = await import(from);

	console.log(object);
	// Default export
	// [Module: null prototype] {
	// 	default: { customMedia: { '--sm': '(min-width: 40em)' } }
	// }

	// Named export
	// [Module: null prototype] {
	// 	customMedia: { '--sm': '(min-width: 40em)' }
	// }
```

## Solution

I added a branch to detect and prioritize default exports.
This follows the same approach as in [csstools/stylelint-value-no-unknown-custom-properties](https://github.com/csstools/stylelint-value-no-unknown-custom-properties/blob/main/src/lib/get-custom-properties-from-imports.mjs)